### PR TITLE
Заменены 3 старых интерфейса на 1 новый.

### DIFF
--- a/androidapimodule/src/main/java/tv/limehd/androidapimodule/Download/BroadcastDownloading.java
+++ b/androidapimodule/src/main/java/tv/limehd/androidapimodule/Download/BroadcastDownloading.java
@@ -43,7 +43,7 @@ public class BroadcastDownloading {
                             throw new IOException("Unexpected code " + response);
                         }
                         if (callBackDownloadBroadCastInterface != null)
-                            callBackDownloadBroadCastInterface.callBackDownloadedBroadCastSucces(response.body().string());
+                            callBackDownloadBroadCastInterface.callBackDownloadedBroadCastSuccess(response.body().string());
                     }
                 });
             }
@@ -53,9 +53,9 @@ public class BroadcastDownloading {
                     , before_date, after_date, time_zone));
     }
 
-
     public interface CallBackDownloadBroadCastInterface {
-        void callBackDownloadedBroadCastSucces(String response);
+
+        void callBackDownloadedBroadCastSuccess(String response);
 
         void callBackDownloadedBroadCastError(String error_message);
     }

--- a/androidapimodule/src/main/java/tv/limehd/androidapimodule/Download/ClientDownloading.java
+++ b/androidapimodule/src/main/java/tv/limehd/androidapimodule/Download/ClientDownloading.java
@@ -40,7 +40,7 @@ public class ClientDownloading {
         BroadcastDownloading broadcastDownloading = new BroadcastDownloading();
         broadcastDownloading.setCallBackDownloadBroadCastInterface(new BroadcastDownloading.CallBackDownloadBroadCastInterface() {
             @Override
-            public void callBackDownloadedBroadCastSucces(String response) {
+            public void callBackDownloadedBroadCastSuccess(String response) {
                 if (callBackDownloadInterface != null)
                     callBackDownloadInterface.callBackDownloadedSuccess(response);
             }

--- a/androidapimodule/src/main/java/tv/limehd/androidapimodule/LimeApiClient.java
+++ b/androidapimodule/src/main/java/tv/limehd/androidapimodule/LimeApiClient.java
@@ -19,13 +19,13 @@ public class LimeApiClient {
                 @Override
                 public void callBackDownloadedSuccess(String response) {
                     if (downloadChannelListCallBack != null)
-                        downloadChannelListCallBack.downloadChannelListSuccess(response);
+                        downloadChannelListCallBack.downloadSuccess(response);
                 }
 
                 @Override
                 public void callBackDownloadedError(String error_message) {
                     if (downloadChannelListCallBack != null)
-                        downloadChannelListCallBack.downloadChannelListError(error_message);
+                        downloadChannelListCallBack.downloadError(error_message);
                 }
             });
             clientDownloading.setCallBackRequestInterface(new ClientDownloading.CallBackRequestInterface() {
@@ -39,19 +39,6 @@ public class LimeApiClient {
         }
     }
 
-    public interface DownloadChannelListCallBack {
-        void downloadChannelListSuccess(String response);
-
-        void downloadChannelListError(String message);
-    }
-
-    private DownloadChannelListCallBack downloadChannelListCallBack;
-
-    public void setDownloadChannelListCallBack(DownloadChannelListCallBack downloadChannelListCallBack) {
-        this.downloadChannelListCallBack = downloadChannelListCallBack;
-    }
-    //endregion
-
     /*Download broadcast*/
     //region DownloadBroadcast
     public void downloadBroadcast(String scheme, String endpoint_broadcast, String channel_id, String before_date, String after_date, String time_zone) {
@@ -61,13 +48,13 @@ public class LimeApiClient {
                 @Override
                 public void callBackDownloadedSuccess(String response) {
                     if (downloadBroadCastCallBack != null)
-                        downloadBroadCastCallBack.downloadBroadCastSuccess(response);
+                        downloadBroadCastCallBack.downloadSuccess(response);
                 }
 
                 @Override
                 public void callBackDownloadedError(String error_message) {
                     if (downloadBroadCastCallBack != null)
-                        downloadBroadCastCallBack.downloadBroadCastError(error_message);
+                        downloadBroadCastCallBack.downloadError(error_message);
                 }
             });
             clientDownloading.setCallBackRequestInterface(new ClientDownloading.CallBackRequestInterface() {
@@ -81,19 +68,6 @@ public class LimeApiClient {
         }
     }
 
-    public interface DownloadBroadCastCallBack {
-        void downloadBroadCastSuccess(String response);
-
-        void downloadBroadCastError(String message);
-    }
-
-    private DownloadBroadCastCallBack downloadBroadCastCallBack;
-
-    public void setDownloadBroadCastCallBack(DownloadBroadCastCallBack downloadBroadCastCallBack) {
-        this.downloadBroadCastCallBack = downloadBroadCastCallBack;
-    }
-    //endregion
-
     //region Download ping
     public void downloadPing(String scheme, String endpoint_ping) {
         if (api_root != null) {
@@ -102,13 +76,13 @@ public class LimeApiClient {
                 @Override
                 public void callBackDownloadedSuccess(String response) {
                     if (downloadPingCallBack != null)
-                        downloadPingCallBack.downloadPingSuccess(response);
+                        downloadPingCallBack.downloadSuccess(response);
                 }
 
                 @Override
                 public void callBackDownloadedError(String error_message) {
                     if (downloadPingCallBack != null)
-                        downloadPingCallBack.downloadPingError(error_message);
+                        downloadPingCallBack.downloadError(error_message);
                 }
             });
             clientDownloading.setCallBackRequestInterface(new ClientDownloading.CallBackRequestInterface() {
@@ -121,19 +95,6 @@ public class LimeApiClient {
             clientDownloading.dowloadPing(scheme, api_root, endpoint_ping);
         }
     }
-
-    public interface DownloadPingCallBack {
-        void downloadPingSuccess(String response);
-
-        void downloadPingError(String message);
-    }
-
-    private DownloadPingCallBack downloadPingCallBack;
-
-    public void setDownloadPingCallBack(DownloadPingCallBack downloadPingCallBack) {
-        this.downloadPingCallBack = downloadPingCallBack;
-    }
-    //endregion
 
     //region RequestCallBack
     public interface RequestCallBack {
@@ -156,4 +117,28 @@ public class LimeApiClient {
         this.requestChannelList = requestChannelList;
     }
     //endregion
+
+    //region DownloadCallBack
+    //Используй для передачи полученных данных
+    public interface DownloadCallBack {
+        void downloadSuccess(String response);
+
+        void downloadError(String message);
+    }
+
+    private DownloadCallBack downloadPingCallBack;
+    private DownloadCallBack downloadChannelListCallBack;
+    private DownloadCallBack downloadBroadCastCallBack;
+
+    public void setDownloadPingCallBack(DownloadCallBack downloadPingCallBack) {
+        this.downloadPingCallBack = downloadPingCallBack;
+    }
+
+    public void setDownloadChannelListCallBack(DownloadCallBack downloadChannelListCallBack) {
+        this.downloadChannelListCallBack = downloadChannelListCallBack;
+    }
+
+    public void setDownloadBroadCastCallBack(DownloadCallBack downloadBroadCastCallBack) {
+        this.downloadBroadCastCallBack = downloadBroadCastCallBack;
+    }
 }

--- a/demo/src/main/java/tv/limehd/androidapiclient/DemoActivity.java
+++ b/demo/src/main/java/tv/limehd/androidapiclient/DemoActivity.java
@@ -19,7 +19,7 @@ import tv.limehd.androidapimodule.LimeApiClient;
 import tv.limehd.androidapimodule.LimeRFC;
 import tv.limehd.androidapimodule.Values.ApiValues;
 
-public class DemoActivity extends Activity implements LimeApiClient.DownloadChannelListCallBack, LimeApiClient.DownloadBroadCastCallBack, LimeApiClient.DownloadPingCallBack {
+public class DemoActivity extends Activity  {
 
     private String LIME_LOG = "limeapilog";
     //экземпляр апи клиента для запросов
@@ -122,9 +122,39 @@ public class DemoActivity extends Activity implements LimeApiClient.DownloadChan
         //инициализация апи значений
         apiValues = new ApiValues();
 
-        limeApiClient.setDownloadChannelListCallBack(this);
-        limeApiClient.setDownloadBroadCastCallBack(this);
-        limeApiClient.setDownloadPingCallBack(this);
+        limeApiClient.setDownloadChannelListCallBack(new LimeApiClient.DownloadCallBack() {
+            @Override
+            public void downloadSuccess(String response) {
+                downloadChannelListSuccess(response);
+            }
+
+            @Override
+            public void downloadError(String message) {
+                downloadChannelListError(message);
+            }
+        });
+        limeApiClient.setDownloadBroadCastCallBack(new LimeApiClient.DownloadCallBack() {
+            @Override
+            public void downloadSuccess(String response) {
+                downloadBroadCastSuccess(response);
+            }
+
+            @Override
+            public void downloadError(String message) {
+                downloadBroadCastError(message);
+            }
+        });
+        limeApiClient.setDownloadPingCallBack(new LimeApiClient.DownloadCallBack() {
+            @Override
+            public void downloadSuccess(String response) {
+                downloadPingSuccess(response);
+            }
+
+            @Override
+            public void downloadError(String message) {
+                downloadPingSuccess(message);
+            }
+        });
 
         setCallBackRequests();
 
@@ -191,37 +221,31 @@ public class DemoActivity extends Activity implements LimeApiClient.DownloadChan
         });
     }
 
-    @Override
     public void downloadChannelListSuccess(String response) {
         Log.e(LIME_LOG, response);
         printAnswer(response);
     }
 
-    @Override
     public void downloadBroadCastSuccess(String response) {
         Log.e(LIME_LOG, response);
         printAnswer(response);
     }
 
-    @Override
     public void downloadPingSuccess(String response) {
         Log.e(LIME_LOG, response);
         printAnswer(response);
     }
 
-    @Override
     public void downloadChannelListError(String message) {
         Log.e(LIME_LOG, message);
         printAnswer(message);
     }
 
-    @Override
     public void downloadBroadCastError(String message) {
         Log.e(LIME_LOG, message);
         printAnswer(message);
     }
 
-    @Override
     public void downloadPingError(String message) {
         Log.e(LIME_LOG, message);
         printAnswer(message);


### PR DESCRIPTION
Заменил интерфейсы в LimeApiClient.
Были:

- `public interface DownloadChannelListCallBack`

- `public interface DownloadPingCallBack`

- `public interface DownloadBroadCastCallBack`

 В каждом интерфейсе по 2 функции.

Стал: `public interface DownloadCallBack ` с 2 функциями, но с тремя экземплярами .

Смысл в том, что если понадобится добавить еще 4 запроса, то не придется создавать еще 4 новых интерфейса, еще 4 экземпляра. И в MainActivity, а в данном случае в DemoActitivy не требуется подключать длинный список интерфейсов: `public class DemoActivity extends Activity implements LimeApiClient.DownloadChannelListCallBack, LimeApiClient.DownloadBroadCastCallBack, LimeApiClient.DownloadPingCallBack`. 

`@Override` функции в Activity будут находиться там, где их определили. Не будет возникать путаницы в том, какая `@Override` функция какому интерфейсу принадлежит.